### PR TITLE
Add links to data overviews

### DIFF
--- a/catmap/src/catmap/ui/component/data_overview_expander.py
+++ b/catmap/src/catmap/ui/component/data_overview_expander.py
@@ -21,7 +21,7 @@ class DataOverviewExpander(AbstractUIComponent):  # pylint: disable=too-few-publ
                     "Stage II is cancer that has grown into nearby tissue. "
                     "Stage III is cancer that has spread to lymph nodes. "
                     "Stage IV is cancer that has spread to distant parts of the body.\n \n"
-                    "https://www.nature.com/articles/s41597-023-02074-6"
+                    "https://www.nature.com/articles/s41597-023-02074-6 \n \n"
                 )
 
         if st.session_state.current_page == "page_2":
@@ -44,5 +44,5 @@ class DataOverviewExpander(AbstractUIComponent):  # pylint: disable=too-few-publ
                     "methylated, the gene is turned off. When it is not methylated, this signifies that a change in "
                     "the DNA code is the reason for mismatch repair deficient cells. This will change the "
                     "treatment plan for the patient.\n \n"
-                    "https://singlecell.broadinstitute.org/single_cell/study/SCP1162/human-colon-cancer-atlas-c295"
+                    "https://singlecell.broadinstitute.org/single_cell/study/SCP1162/human-colon-cancer-atlas-c295 \n \n"
                 )

--- a/catmap/src/catmap/ui/component/data_overview_expander.py
+++ b/catmap/src/catmap/ui/component/data_overview_expander.py
@@ -15,12 +15,13 @@ class DataOverviewExpander(AbstractUIComponent):  # pylint: disable=too-few-publ
                 parent.markdown(
                     "Study: The study that collected the sample of cells.\n \n"
                     "Patient: The patient the sample is from. \n \n"
-                    "Cluster Level 1: The high level type of cell (9 total)\n \n"
-                    "Cluster Level 2: More specific cell types (27 total)\n \n"
+                    "Cluster Level 1: The high level type of cell (9 total).\n \n"
+                    "Cluster Level 2: More specific cell types (27 total).\n \n"
                     "Stage: The stage of Cancer. Stage I is a small tumor that hasn't spread. "
                     "Stage II is cancer that has grown into nearby tissue. "
                     "Stage III is cancer that has spread to lymph nodes. "
-                    "Stage IV is cancer that has spread to distant parts of the body."
+                    "Stage IV is cancer that has spread to distant parts of the body.\n \n"
+                    "https://www.nature.com/articles/s41597-023-02074-6"
                 )
 
         if st.session_state.current_page == "page_2":
@@ -43,4 +44,5 @@ class DataOverviewExpander(AbstractUIComponent):  # pylint: disable=too-few-publ
                     "methylated, the gene is turned off. When it is not methylated, this signifies that a change in "
                     "the DNA code is the reason for mismatch repair deficient cells. This will change the "
                     "treatment plan for the patient.\n \n"
+                    "https://singlecell.broadinstitute.org/single_cell/study/SCP1162/human-colon-cancer-atlas-c295"
                 )

--- a/catmap/src/catmap/ui/component/data_overview_expander.py
+++ b/catmap/src/catmap/ui/component/data_overview_expander.py
@@ -21,6 +21,7 @@ class DataOverviewExpander(AbstractUIComponent):  # pylint: disable=too-few-publ
                     "Stage II is cancer that has grown into nearby tissue. "
                     "Stage III is cancer that has spread to lymph nodes. "
                     "Stage IV is cancer that has spread to distant parts of the body.\n \n"
+                    "This data is based on the NSCLC data from "
                     "https://www.nature.com/articles/s41597-023-02074-6 \n \n"
                 )
 
@@ -44,5 +45,6 @@ class DataOverviewExpander(AbstractUIComponent):  # pylint: disable=too-few-publ
                     "methylated, the gene is turned off. When it is not methylated, this signifies that a change in "
                     "the DNA code is the reason for mismatch repair deficient cells. This will change the "
                     "treatment plan for the patient.\n \n"
+                    "This data is based on the Colon Cancer data from "
                     "https://singlecell.broadinstitute.org/single_cell/study/SCP1162/human-colon-cancer-atlas-c295 \n \n"
                 )


### PR DESCRIPTION
This adds the links to the cancer studies in the data overview dropdown that are used in the visualizations. This was tested by viewing in the app. Existing tests cover this.