### PR TITLE
Expand documentation and tests

### DIFF
--- a/catmap/src/catmap/app.py
+++ b/catmap/src/catmap/app.py
@@ -16,9 +16,11 @@ from catmap.ui.component.embed_results_page import EmbedResultsPage
 from catmap.ui.component.homepage_header import HomePageHeader
 
 
-
 def start():
-    """Sets up the components and initializes the state."""
+    """
+    Sets up the page components and initializes the state. Also create buttons which can set the
+    session_state.current_page to the desired page.
+    """
     _initialize_state()
 
     # Header().build(st)
@@ -39,7 +41,7 @@ def start():
             unsafe_allow_html=True
         )
         st.markdown("<h3 style='text-align: center;'>Navigate to catmaps with "
-        "different visualizations:</h3>", unsafe_allow_html=True)
+                    "different visualizations:</h3>", unsafe_allow_html=True)
 
         _, col1, _, col3 = st.columns([0.175, 0.325, 0.10, 0.40])
 

--- a/catmap/src/catmap/ui/component/abstract_component.py
+++ b/catmap/src/catmap/ui/component/abstract_component.py
@@ -1,4 +1,9 @@
-"""Base module for UI component."""
+"""
+Base module for UI component.
+
+This holds an abstract class which defines a single method "build" which is used to describe how
+the concrete component is built onto it's parent streamlit container.
+"""
 from abc import ABC, abstractmethod
 
 from streamlit.delta_generator import DeltaGenerator

--- a/catmap/src/catmap/ui/component/data_overview_expander.py
+++ b/catmap/src/catmap/ui/component/data_overview_expander.py
@@ -10,7 +10,8 @@ class DataOverviewExpander(AbstractUIComponent):  # pylint: disable=too-few-publ
 
     def build(self, parent: DeltaGenerator) -> DeltaGenerator:
         """
-        Creates the visualization overview expander.
+        Creates the visualization overview expander. Reacts to session_state.current_page to
+        choose which data to display.
 
         Args:
             parent (DeltaGenerator): The parent streamlit container to attach to.

--- a/catmap/src/catmap/ui/component/data_overview_expander.py
+++ b/catmap/src/catmap/ui/component/data_overview_expander.py
@@ -9,7 +9,13 @@ class DataOverviewExpander(AbstractUIComponent):  # pylint: disable=too-few-publ
     """Class to create visualization overview expander."""
 
     def build(self, parent: DeltaGenerator) -> DeltaGenerator:
-        """Creates the visualization overview expander."""
+        """
+        Creates the visualization overview expander.
+
+        Args:
+            parent (DeltaGenerator): The parent streamlit container to attach to.
+            Could be a column or the root st object.
+        """
         if st.session_state.current_page == "page_1":
             with parent.expander("Data Overview"):
                 parent.markdown(

--- a/catmap/src/catmap/ui/component/embed_results_page.py
+++ b/catmap/src/catmap/ui/component/embed_results_page.py
@@ -14,7 +14,7 @@ from catmap.io.model_loader import embed_nsclc_data
 class EmbedResultsPage(AbstractUIComponent):
     def build(self, parent: DeltaGenerator):
         """
-        Builds the embed results component
+        Builds the embed results component. Does not rely on session_state.
 
         Args:
             parent (DeltaGenerator): The parent container to build onto.

--- a/catmap/src/catmap/ui/component/embedding_plotter.py
+++ b/catmap/src/catmap/ui/component/embedding_plotter.py
@@ -30,7 +30,8 @@ class EmbeddingPlotter(AbstractUIComponent):  # pylint: disable=too-few-public-m
 
     def build(self, parent: DeltaGenerator):
         """
-        Builds the component which plots the embedding data.
+        Builds the component which plots the embedding data. Also relies on
+        session_state.current_page to adjust the size of the markers for the embed page.
 
         Args:
             parent (DeltaGenerator): The parent streamlit container to attach to.

--- a/catmap/src/catmap/ui/component/embedding_plotter.py
+++ b/catmap/src/catmap/ui/component/embedding_plotter.py
@@ -28,13 +28,20 @@ class EmbeddingPlotter(AbstractUIComponent):  # pylint: disable=too-few-public-m
         self.xlab = xlab
         self.ylab = ylab
 
-    def build(self, parent: DeltaGenerator) -> DeltaGenerator:
-        """Builds the component which plots the embedding data."""
+    def build(self, parent: DeltaGenerator):
+        """
+        Builds the component which plots the embedding data.
+
+        Args:
+            parent (DeltaGenerator): The parent streamlit container to attach to.
+            Could be a column or the root st object.
+        """
         fig = px.scatter(self.df, x=self.xlab,
                          y=self.ylab, color=self.column,
-                         category_orders={"Stage": ["I", "II", "III", "III/IV", "IV"]},
+                         category_orders={
+                             "Stage": ["I", "II", "III", "III/IV", "IV"]},
                          opacity=0.7)
-        fig.update_layout(legend= {'itemsizing': 'constant'})
+        fig.update_layout(legend={'itemsizing': 'constant'})
         if st.session_state.current_page == "embed":
             fig.update_traces(marker=dict(size=10))
         else:

--- a/catmap/src/catmap/ui/component/header.py
+++ b/catmap/src/catmap/ui/component/header.py
@@ -4,8 +4,15 @@ from streamlit.delta_generator import DeltaGenerator
 from catmap.ui.component.abstract_component import AbstractUIComponent
 
 
-class Header(AbstractUIComponent): # pylint: disable=too-few-public-methods
+class Header(AbstractUIComponent):  # pylint: disable=too-few-public-methods
     """Class to write title."""
-    def build(self, parent: DeltaGenerator) -> DeltaGenerator:
-        """Writes the title."""
+
+    def build(self, parent: DeltaGenerator):
+        """
+        Writes the title.
+
+        Args:
+            parent (DeltaGenerator): The parent streamlit container to attach to.
+            Could be a column or the root st object.
+        """
         parent.title("catmap")

--- a/catmap/src/catmap/ui/component/homepage_header.py
+++ b/catmap/src/catmap/ui/component/homepage_header.py
@@ -1,10 +1,19 @@
+"""Module to create the home page header UI component."""
 import streamlit as st
+from streamlit.delta_generator import DeltaGenerator
+
 
 class HomePageHeader:
-    """Class to write a fully centered title and navigation buttons."""
+    """Class to write a fully centered title."""
 
-    def build(self, parent: st.delta_generator.DeltaGenerator) -> None:
-        """Creates a centered title and places navigation buttons below it."""
+    def build(self, parent: DeltaGenerator):
+        """
+        Creates a centered title and places navigation buttons below it.
+
+        Args:
+            parent (DeltaGenerator): The parent streamlit container to attach to.
+            Could be a column or the root st object.
+        """
         custom_html = """
         <style>
         h1 {

--- a/catmap/src/catmap/ui/component/info_button.py
+++ b/catmap/src/catmap/ui/component/info_button.py
@@ -5,16 +5,23 @@ from streamlit.delta_generator import DeltaGenerator
 from catmap.ui.component.abstract_component import AbstractUIComponent
 
 
-class InfoButton(AbstractUIComponent): # pylint: disable=too-few-public-methods
+class InfoButton(AbstractUIComponent):  # pylint: disable=too-few-public-methods
     """Class to create info button."""
 
     def toggle_button_state(self):
         """Helper function to toggle the state of the button"""
         st.session_state.button = not st.session_state.button
 
-    def build(self, parent: DeltaGenerator) -> DeltaGenerator:
-        """Creates the info button."""
-        parent.button(":information_source:", on_click=self.toggle_button_state)
+    def build(self, parent: DeltaGenerator):
+        """
+        Creates the info button.
+
+        Args:
+            parent (DeltaGenerator): The parent streamlit container to attach to.
+            Could be a column or the root st object.
+        """
+        parent.button(":information_source:",
+                      on_click=self.toggle_button_state)
         if st.session_state.button:
             if st.session_state.current_page == "page_1":
                 st.info(f"Double click on a {st.session_state.selected_column_nsclc} option "

--- a/catmap/src/catmap/ui/component/info_button.py
+++ b/catmap/src/catmap/ui/component/info_button.py
@@ -14,7 +14,9 @@ class InfoButton(AbstractUIComponent):  # pylint: disable=too-few-public-methods
 
     def build(self, parent: DeltaGenerator):
         """
-        Creates the info button.
+        Creates the info button. Relies on session_state.button and session_state.current_page to
+        change what information to display and draws from the column option for both pages to
+        dynamically display an informative help tip.
 
         Args:
             parent (DeltaGenerator): The parent streamlit container to attach to.

--- a/catmap/src/catmap/ui/component/page_1.py
+++ b/catmap/src/catmap/ui/component/page_1.py
@@ -18,8 +18,14 @@ class Page1(AbstractUIComponent):  # pylint: disable=too-few-public-methods
     """Class for displaying NSCLC embeddings and information."""
 
     def build(self, parent: DeltaGenerator) -> DeltaGenerator:
-        """Sets up the components and initializes the state."""
-        col1,col2,col3 = parent.columns([0.15,0.7,0.15])
+        """
+        Sets up the components and initializes the state for the NSCLC page.
+
+        Args:
+            parent (DeltaGenerator): The parent streamlit container to attach to.
+            Could be a column or the root st object.
+        """
+        col1, col2, col3 = parent.columns([0.15, 0.7, 0.15])
 
         with col1:
             st.write("")
@@ -44,7 +50,7 @@ class Page1(AbstractUIComponent):  # pylint: disable=too-few-public-methods
 
             data_overview_expander = DataOverviewExpander()
             data_overview_expander.build(parent)
-        
+
             open_embedding_page_button = OpenEmbeddingPageButton()
             open_embedding_page_button.build(parent)
 

--- a/catmap/src/catmap/ui/component/page_1.py
+++ b/catmap/src/catmap/ui/component/page_1.py
@@ -19,7 +19,8 @@ class Page1(AbstractUIComponent):  # pylint: disable=too-few-public-methods
 
     def build(self, parent: DeltaGenerator) -> DeltaGenerator:
         """
-        Sets up the components and initializes the state for the NSCLC page.
+        Sets up the components and initializes the state for the NSCLC page. Relies on NSCLC
+        related session state including the selected column, dataframe, and column options.
 
         Args:
             parent (DeltaGenerator): The parent streamlit container to attach to.

--- a/catmap/src/catmap/ui/component/page_2.py
+++ b/catmap/src/catmap/ui/component/page_2.py
@@ -16,9 +16,15 @@ from catmap.ui.component.data_overview_expander import DataOverviewExpander
 class Page2(AbstractUIComponent):  # pylint: disable=too-few-public-methods
     """Class for displaying colon cancer embeddings and information."""
 
-    def build(self, parent: DeltaGenerator) -> DeltaGenerator:
-        """Sets up the components and initializes the state."""
-        col1,col2,col3 = parent.columns([0.15,0.7,0.15])
+    def build(self, parent: DeltaGenerator):
+        """
+        Sets up the components and initializes the state for the colon cancer page.
+
+        Args:
+            parent (DeltaGenerator): The parent streamlit container to attach to.
+            Could be a column or the root st object.
+        """
+        col1, col2, col3 = parent.columns([0.15, 0.7, 0.15])
 
         with col1:
             st.write("")

--- a/catmap/src/catmap/ui/component/page_2.py
+++ b/catmap/src/catmap/ui/component/page_2.py
@@ -18,7 +18,9 @@ class Page2(AbstractUIComponent):  # pylint: disable=too-few-public-methods
 
     def build(self, parent: DeltaGenerator):
         """
-        Sets up the components and initializes the state for the colon cancer page.
+        Sets up the components and initializes the state for the colon cancer page. Relies on
+        colon cancer related session state including the selected column, dataframe, and column
+        options.
 
         Args:
             parent (DeltaGenerator): The parent streamlit container to attach to.

--- a/catmap/src/catmap/ui/component/return_home_button.py
+++ b/catmap/src/catmap/ui/component/return_home_button.py
@@ -10,7 +10,7 @@ class ReturnHomeButton(AbstractUIComponent):  # pylint: disable=too-few-public-m
 
     def build(self, parent: DeltaGenerator):
         """
-        Creates the back to home button.
+        Creates the back to home button which sets the session_state current to "home".
 
         Args:
             parent (DeltaGenerator): The parent streamlit container to attach to.

--- a/catmap/src/catmap/ui/component/return_home_button.py
+++ b/catmap/src/catmap/ui/component/return_home_button.py
@@ -8,8 +8,14 @@ from catmap.ui.component.abstract_component import AbstractUIComponent
 class ReturnHomeButton(AbstractUIComponent):  # pylint: disable=too-few-public-methods
     """Class to create back to home button."""
 
-    def build(self, parent: DeltaGenerator) -> DeltaGenerator:
-        """Creates the back to home button."""
+    def build(self, parent: DeltaGenerator):
+        """
+        Creates the back to home button.
+
+        Args:
+            parent (DeltaGenerator): The parent streamlit container to attach to.
+            Could be a column or the root st object.
+        """
 
         if parent.button("Back to Home"):
             st.session_state.current_page = "home"

--- a/catmap/src/catmap/ui/component/visualization_overview_expander.py
+++ b/catmap/src/catmap/ui/component/visualization_overview_expander.py
@@ -10,7 +10,8 @@ class VisualizationOverviewExpander(AbstractUIComponent):  # pylint: disable=too
 
     def build(self, parent: DeltaGenerator):
         """
-        Creates the visualization overview expander.
+        Creates the visualization overview expander. Dynamically adjusts content based on
+        session_state.current_page.
 
         Args:
             parent (DeltaGenerator): The parent streamlit container to attach to.

--- a/catmap/src/catmap/ui/component/visualization_overview_expander.py
+++ b/catmap/src/catmap/ui/component/visualization_overview_expander.py
@@ -5,11 +5,17 @@ from streamlit.delta_generator import DeltaGenerator
 from catmap.ui.component.abstract_component import AbstractUIComponent
 
 
-class VisualizationOverviewExpander(AbstractUIComponent): # pylint: disable=too-few-public-methods
+class VisualizationOverviewExpander(AbstractUIComponent):  # pylint: disable=too-few-public-methods
     """Class to create visualization overview expander."""
 
-    def build(self, parent: DeltaGenerator) -> DeltaGenerator:
-        """Creates the visualization overview expander."""
+    def build(self, parent: DeltaGenerator):
+        """
+        Creates the visualization overview expander.
+
+        Args:
+            parent (DeltaGenerator): The parent streamlit container to attach to.
+            Could be a column or the root st object.
+        """
         with parent.expander("Visualization Overview"):
             if st.session_state.current_page == "page_1":
                 st.markdown("""
@@ -23,7 +29,7 @@ class VisualizationOverviewExpander(AbstractUIComponent): # pylint: disable=too-
                     Interact with the filter dropdown above the plot to view the catmap with different 
                             groupings based on variables available in the data. 
                     """
-                )
+                            )
             if st.session_state.current_page == "page_2":
                 st.markdown("""
                     catmap stands for ca(ncer) t(ranscriptomics) map. It is a tool used to 
@@ -36,4 +42,4 @@ class VisualizationOverviewExpander(AbstractUIComponent): # pylint: disable=too-
                     Interact with the filter dropdown above the plot to view the catmap with different 
                             groupings based on variables available in the data. 
                     """
-                )
+                            )

--- a/catmap/tests/test_launcher.py
+++ b/catmap/tests/test_launcher.py
@@ -1,0 +1,19 @@
+"""Test module for the catmap launcher."""
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+from catmap import app
+from catmap import launcher
+
+
+class TestLauncher(unittest.TestCase):
+    """Test class for testing the launcher."""
+
+    @patch("streamlit.web.cli.main_run")
+    def test_main(self, mock_main_run):
+        """Test that the streamlit cli runner is called with the location of our app script."""
+        launcher.main()
+
+        mock_main_run.assert_called_with([str(Path(app.__file__).resolve())])
+

--- a/catmap/tests/test_launcher.py
+++ b/catmap/tests/test_launcher.py
@@ -16,4 +16,3 @@ class TestLauncher(unittest.TestCase):
         launcher.main()
 
         mock_main_run.assert_called_with([str(Path(app.__file__).resolve())])
-


### PR DESCRIPTION
I thought we should document the argument of the UI components to say they are taking in the parent streamlit container they will build onto. I also documented what state they expect.

Finally I added a test for the launcher just making sure that functionality stays working.

This change doesn't add any functionality just one new test case and class / documentation.